### PR TITLE
Remove re.DOTALL to prevent wrong matches

### DIFF
--- a/turnboxed/basebot.py
+++ b/turnboxed/basebot.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
     from script import *
     with open(script.__file__, 'r') as f:
         script_content = f.read()
-    cs = re.findall('class\ (.*?)\(BaseBot', script_content, re.DOTALL)
+    cs = re.findall('class\ (.*?)\(BaseBot', script_content)
     if len(cs) > 0:
         klass = globals()[cs[-1]]
         bot_instance = klass()


### PR DESCRIPTION
If you have classes defined before the bot, the regular expression matches all the text between
